### PR TITLE
Change repo name from `wordpress-*` to `wp-*` to avoid trademark violation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ The username is `admin` and the password is `password`.
 For the other `wp-env` commands, see the [Command Reference](https://github.com/wordPress/gutenberg/tree/trunk/packages/env#command-reference).
 
 ## Exercises
-1. [Block Registration](https://github.com/kienstra/wordpress-block-tutorial/blob/exercise/1-block-registration/INSTRUCTIONS.md)
-2. [Edit Component](https://github.com/kienstra/wordpress-block-tutorial/blob/exercise/2-edit-component/INSTRUCTIONS.md)
-3. [Progress Indicator Component](https://github.com/kienstra/wordpress-block-tutorial/blob/exercise/3-progress-indicator/INSTRUCTIONS.md)
-4. [Save Component](https://github.com/kienstra/wordpress-block-tutorial/blob/exercise/4-save-component/INSTRUCTIONS.md)
+1. [Block Registration](https://github.com/kienstra/wp-block-tutorial/blob/exercise/1-block-registration/INSTRUCTIONS.md)
+2. [Edit Component](https://github.com/kienstra/wp-block-tutorial/blob/exercise/2-edit-component/INSTRUCTIONS.md)
+3. [Progress Indicator Component](https://github.com/kienstra/wp-block-tutorial/blob/exercise/3-progress-indicator/INSTRUCTIONS.md)
+4. [Save Component](https://github.com/kienstra/wp-block-tutorial/blob/exercise/4-save-component/INSTRUCTIONS.md)
 
 ## Exercise Steps
 This format is [taken from](https://github.com/kentcdodds/bookshelf/tree/6b4a484eb61c3e7bb27d151ca32b041662922536#workflow) Kent C. Dodds.
 
-1. `checkout` the branch for the exercise, like [exercise/1-block-json](https://github.com/kienstra/wordpress-block-tutorial/tree/exercise/1-block-registration)
+1. `checkout` the branch for the exercise, like [exercise/1-block-json](https://github.com/kienstra/wp-block-tutorial/tree/exercise/1-block-registration)
 2. Read `INSTRUCTIONS.md`
 3. Find the `Files` heading in `INSTRUCTIONS.md`, and edit its files
 4. 🚧 will show where to edit

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kienstra/progress-indicator",
   "type": "wordpress-plugin",
   "description": "A block for adding a progress indicator",
-  "homepage": "https://github.com/kienstra/wordpress-block-tutorial",
+  "homepage": "https://github.com/kienstra/wp-block-tutorial",
   "license": "GPL-2.0",
   "require": {
     "php": "^5.6 || ^7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "wordpress-block-tutorial",
+  "name": "wp-block-tutorial",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wordpress-block-tutorial",
+  "name": "wp-block-tutorial",
   "version": "0.1.0",
   "description": "A block for adding a progress indicator",
   "author": "Rob Stinson",
@@ -7,11 +7,11 @@
   "keywords": [
     "wordpress"
   ],
-  "homepage": "https://github.com/kienstra/wordpress-block-tutorial",
+  "homepage": "https://github.com/kienstra/wp-block-tutorial",
   "repository": {
-    "url": "https://github.com/kienstra/wordpress-block-tutorial/issues"
+    "url": "https://github.com/kienstra/wp-block-tutorial/issues"
   },
-  "bugs": "https://github.com/kienstra/wordpress-block-tutorial/issues",
+  "bugs": "https://github.com/kienstra/wp-block-tutorial/issues",
   "engines": {
     "node": "14"
   },


### PR DESCRIPTION
* Change repo name from `wordpress-*` to `wp-*` to avoid trademark violation